### PR TITLE
Add users info endpoint

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -15,9 +15,19 @@ function checkLimit(Request $request, Response $response, array $args): Response
         ->withHeader('Content-Type', 'text/plain')
         ->withStatus(200);
 }
+function usersInfo(Request $request, Response $response): Response {
+    $checker = new LimitChecker();
+    $data = $checker->getUsersTimeLeft();
+    $response->getBody()->write(json_encode($data));
+    return $response
+        ->withHeader("Content-Type", "application/json")
+        ->withStatus(200);
+}
+
 
 
 
 return function (App $app) {
     $app->get('/api/limits/check/{pc}', 'checkLimit');
+    $app->get('/api/limits/users', 'usersInfo');
 };


### PR DESCRIPTION
## Summary
- add helper methods in `LimitChecker` to compute remaining minutes
- expose `getUsersTimeLeft` public method
- add `/api/limits/users` route returning all active user sessions

## Testing
- `php -l src/routes.php`
- `php -l src/Services/LimitChecker.php`

------
https://chatgpt.com/codex/tasks/task_e_6888a5140e34832088ad267e060d5c3e