### PR TITLE
Add CRUD routes for limits and groups

### DIFF
--- a/src/Models/UserGroup.php
+++ b/src/Models/UserGroup.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 class UserGroup extends Model
 {
     protected $table = 'UserGroups';
+    /** the table uses simple integer id */
+    protected $primaryKey = 'Id';
     public $timestamps = false;
     protected $fillable = ['Group', 'WindowsUser'];
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -4,6 +4,8 @@ use Slim\App;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use App\Services\LimitChecker;
+use App\Models\GroupModuleLimit;
+use App\Models\UserGroup;
 
 return function (App $app) {
 
@@ -33,6 +35,110 @@ return function (App $app) {
 
         $response->getBody()->write($body);
         return $response->withStatus($status)->withHeader('Content-Type', 'text/plain');
+    });
+
+    // ----- Group module limits -----
+    $app->get('/api/group-module-limits', function (Request $request, Response $response): Response {
+        $limits = GroupModuleLimit::all();
+        $response->getBody()->write($limits->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
+
+    $app->get('/api/group-module-limits/{id}', function (Request $request, Response $response, array $args): Response {
+        $limit = GroupModuleLimit::find($args['id']);
+        if (!$limit) {
+            return $response->withStatus(404);
+        }
+        $response->getBody()->write($limit->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
+
+    $app->post('/api/group-module-limits', function (Request $request, Response $response): Response {
+        $data = (array)$request->getParsedBody();
+        $limit = new GroupModuleLimit();
+        $limit->GroupCode = $data['GroupCode'] ?? null;
+        $limit->Module = $data['Module'] ?? null;
+        $limit->Hour = $data['Hour'] ?? null;
+        $limit->MaxLicenses = $data['MaxLicenses'] ?? null;
+        $limit->save();
+        $response->getBody()->write($limit->toJson());
+        return $response->withHeader('Content-Type', 'application/json')->withStatus(201);
+    });
+
+    $app->put('/api/group-module-limits/{id}', function (Request $request, Response $response, array $args): Response {
+        $limit = GroupModuleLimit::find($args['id']);
+        if (!$limit) {
+            return $response->withStatus(404);
+        }
+        $data = (array)$request->getParsedBody();
+        foreach (['GroupCode', 'Module', 'Hour', 'MaxLicenses'] as $field) {
+            if (array_key_exists($field, $data)) {
+                $limit->$field = $data[$field];
+            }
+        }
+        $limit->save();
+        $response->getBody()->write($limit->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
+
+    $app->delete('/api/group-module-limits/{id}', function (Request $request, Response $response, array $args): Response {
+        $limit = GroupModuleLimit::find($args['id']);
+        if (!$limit) {
+            return $response->withStatus(404);
+        }
+        $limit->delete();
+        return $response->withStatus(204);
+    });
+
+    // ----- User groups -----
+    $app->get('/api/user-groups', function (Request $request, Response $response): Response {
+        $groups = UserGroup::all();
+        $response->getBody()->write($groups->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
+
+    $app->get('/api/user-groups/{id}', function (Request $request, Response $response, array $args): Response {
+        $group = UserGroup::find($args['id']);
+        if (!$group) {
+            return $response->withStatus(404);
+        }
+        $response->getBody()->write($group->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
+
+    $app->post('/api/user-groups', function (Request $request, Response $response): Response {
+        $data = (array)$request->getParsedBody();
+        $group = new UserGroup();
+        $group->Group = $data['Group'] ?? null;
+        $group->WindowsUser = $data['WindowsUser'] ?? null;
+        $group->save();
+        $response->getBody()->write($group->toJson());
+        return $response->withHeader('Content-Type', 'application/json')->withStatus(201);
+    });
+
+    $app->put('/api/user-groups/{id}', function (Request $request, Response $response, array $args): Response {
+        $group = UserGroup::find($args['id']);
+        if (!$group) {
+            return $response->withStatus(404);
+        }
+        $data = (array)$request->getParsedBody();
+        foreach (['Group', 'WindowsUser'] as $field) {
+            if (array_key_exists($field, $data)) {
+                $group->$field = $data[$field];
+            }
+        }
+        $group->save();
+        $response->getBody()->write($group->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
+
+    $app->delete('/api/user-groups/{id}', function (Request $request, Response $response, array $args): Response {
+        $group = UserGroup::find($args['id']);
+        if (!$group) {
+            return $response->withStatus(404);
+        }
+        $group->delete();
+        return $response->withStatus(204);
     });
 
 };


### PR DESCRIPTION
## Summary
- expose group module limit CRUD endpoints
- expose user group CRUD endpoints
- declare primary key in `UserGroup` model

## Testing
- `composer install`
- `php -l src/routes.php`
- `php -l src/Models/UserGroup.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6889fa9f03e48320affccf4a6f01fa5f