### PR TITLE
Add API key middleware

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,6 +3,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Slim\Factory\AppFactory;
 use Illuminate\Database\Capsule\Manager as Capsule;
+use App\Middleware\AuthMiddleware;
 
 date_default_timezone_set('Europe/Warsaw');
 
@@ -23,6 +24,9 @@ $capsule->addConnection([
 
 $capsule->setAsGlobal();
 $capsule->bootEloquent();
+
+// Protect write routes with API key middleware
+$app->add(new AuthMiddleware());
 
 // Маршруты
 (require __DIR__ . '/../src/routes.php')($app);

--- a/src/Middleware/AuthMiddleware.php
+++ b/src/Middleware/AuthMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Middleware;
+
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Slim\Psr7\Response;
+
+class AuthMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $method = strtoupper($request->getMethod());
+        if (in_array($method, ['POST', 'PUT', 'DELETE'])) {
+            $apiKey = $request->getHeaderLine('X-API-Key');
+            $valid = getenv('API_KEY') ?: 'secret';
+            if ($apiKey !== $valid) {
+                $response = new Response();
+                $response->getBody()->write('Unauthorized');
+                return $response->withStatus(401);
+            }
+        }
+        return $handler->handle($request);
+    }
+}


### PR DESCRIPTION
## Summary
- add API key middleware for POST/PUT/DELETE protection
- register middleware in the Slim entrypoint

## Testing
- `composer validate --no-check-publish`
- `php -l src/Middleware/AuthMiddleware.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6889fda163488320ba748863179aea30