### PR TITLE
Add schedule lookup endpoint

### DIFF
--- a/src/Services/LimitChecker.php
+++ b/src/Services/LimitChecker.php
@@ -147,6 +147,36 @@ class LimitChecker
         return $info;
     }
 
+    /**
+     * Get schedule of allowed hours for all modules for a given user.
+     *
+     * @param string $userName
+     * @return array<string, array<int>>
+     */
+    public function getUserSchedule(string $userName): array
+    {
+        $group = $this->userGroups[$userName] ?? null;
+        if (!$group || !isset($this->groupModuleLimits[$group])) {
+            return [];
+        }
+
+        $schedule = [];
+        foreach ($this->groupModuleLimits[$group] as $module => $hours) {
+            $allowed = [];
+            foreach ($hours as $h => $max) {
+                if ((int)$max > 0) {
+                    $allowed[] = (int)$h;
+                }
+            }
+            sort($allowed);
+            if (!empty($allowed)) {
+                $schedule[$module] = $allowed;
+            }
+        }
+
+        return $schedule;
+    }
+
 
     public function check(string $pc): array
     {

--- a/src/routes.php
+++ b/src/routes.php
@@ -25,6 +25,13 @@ return function (App $app) {
         return $response->withHeader("Content-Type", "application/json")->withStatus(200);
     });
 
+    $app->get('/api/schedule/{userName}', function (Request $request, Response $response, array $args): Response {
+        $checker = new LimitChecker();
+        $schedule = $checker->getUserSchedule($args['userName']);
+        $response->getBody()->write(json_encode($schedule));
+        return $response->withHeader('Content-Type', 'application/json')->withStatus(200);
+    });
+
     $app->post('/api/limits/users/session/stop/{user}', function (Request $request, Response $response, array $args): Response {
         $user = $args['user'];
         $forceKill = $request->getHeaderLine('X-Force-Kill') === '1';


### PR DESCRIPTION
## Summary
- add `getUserSchedule` method to `LimitChecker`
- expose new GET `/api/schedule/{userName}` route

## Testing
- `composer install`
- `php -l src/Services/LimitChecker.php`
- `php -l src/routes.php`


------
https://chatgpt.com/codex/tasks/task_e_688c778076ec83208219cb21a69241d0