### PR TITLE
Move exception users to database

### DIFF
--- a/src/Models/ExceptionUser.php
+++ b/src/Models/ExceptionUser.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ExceptionUser extends Model
+{
+    protected $table = 'ExceptionUsers';
+    protected $primaryKey = 'Id';
+    public $timestamps = false;
+    protected $fillable = ['UserName'];
+}

--- a/src/Services/LimitChecker.php
+++ b/src/Services/LimitChecker.php
@@ -7,15 +7,11 @@ use App\Models\UserGroup;
 use App\Models\ModuleLimit;
 use App\Models\GroupModuleLimit;
 use App\Models\LinkedModule;
+use App\Models\ExceptionUser;
 
 class LimitChecker
 {
-    private array $exceptionUsers = [
-        'ADMIN',
-        'Zarząd',
-        'Biuro Księgowe',
-        'TSL SILESIA SP. Z O.O.'
-    ];
+    private array $exceptionUsers = [];
 
     private array $userGroups = []; // [UserName => Group]
     private array $groupModuleLimits = [];
@@ -32,6 +28,8 @@ class LimitChecker
             $xml = simplexml_load_file($cfgPath);
             $this->activeUsersCheck = intval($xml->ActiveUsersCheck ?? 0);
         }
+
+        $this->exceptionUsers = ExceptionUser::pluck('UserName')->toArray();
 
         $this->userGroups = UserGroup::all()
             ->mapWithKeys(fn($u) => [$u->UserName => $u->Group])

--- a/src/routes.php
+++ b/src/routes.php
@@ -6,6 +6,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use App\Services\LimitChecker;
 use App\Models\GroupModuleLimit;
 use App\Models\UserGroup;
+use App\Models\ExceptionUser;
 
 return function (App $app) {
 
@@ -156,6 +157,54 @@ return function (App $app) {
             return $response->withStatus(404);
         }
         $group->delete();
+        return $response->withStatus(204);
+    });
+
+    // ----- Exception users -----
+    $app->get('/api/exception-users', function (Request $request, Response $response): Response {
+        $users = ExceptionUser::all();
+        $response->getBody()->write($users->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
+
+    $app->get('/api/exception-users/{id}', function (Request $request, Response $response, array $args): Response {
+        $user = ExceptionUser::find($args['id']);
+        if (!$user) {
+            return $response->withStatus(404);
+        }
+        $response->getBody()->write($user->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
+
+    $app->post('/api/exception-users', function (Request $request, Response $response): Response {
+        $data = json_decode($request->getBody()->getContents(), true);
+        $user = new ExceptionUser();
+        $user->UserName = $data['UserName'] ?? null;
+        $user->save();
+        $response->getBody()->write($user->toJson());
+        return $response->withHeader('Content-Type', 'application/json')->withStatus(201);
+    });
+
+    $app->put('/api/exception-users/{id}', function (Request $request, Response $response, array $args): Response {
+        $user = ExceptionUser::find($args['id']);
+        if (!$user) {
+            return $response->withStatus(404);
+        }
+        $data = json_decode($request->getBody()->getContents(), true);
+        if (array_key_exists('UserName', $data)) {
+            $user->UserName = $data['UserName'];
+        }
+        $user->save();
+        $response->getBody()->write($user->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
+
+    $app->delete('/api/exception-users/{id}', function (Request $request, Response $response, array $args): Response {
+        $user = ExceptionUser::find($args['id']);
+        if (!$user) {
+            return $response->withStatus(404);
+        }
+        $user->delete();
         return $response->withStatus(204);
     });
 };


### PR DESCRIPTION
## Summary
- add `ExceptionUser` model for names stored in new `ExceptionUsers` table
- load exception users from DB in `LimitChecker`
- expose CRUD `/api/exception-users` endpoints

## Testing
- `php -l src/Models/ExceptionUser.php`
- `php -l src/Services/LimitChecker.php`
- `php -l src/routes.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_6891dff6d4cc8320bbfaeea6ffdc7ec3