### PR TITLE
Add Swagger documentation

### DIFF
--- a/src/Models/ExceptionUser.php
+++ b/src/Models/ExceptionUser.php
@@ -2,7 +2,15 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Schema(
+ *     schema="ExceptionUser",
+ *     @OA\Property(property="Id", type="integer"),
+ *     @OA\Property(property="UserName", type="string")
+ * )
+ */
 class ExceptionUser extends Model
 {
     protected $table = 'ExceptionUsers';

--- a/src/Models/GroupModuleLimit.php
+++ b/src/Models/GroupModuleLimit.php
@@ -2,9 +2,19 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use OpenApi\Annotations as OA;
 
 /**
  * Model for per-group module limits by hour.
+ *
+ * @OA\Schema(
+ *     schema="GroupModuleLimit",
+ *     @OA\Property(property="Id", type="integer"),
+ *     @OA\Property(property="GroupCode", type="string"),
+ *     @OA\Property(property="Module", type="string"),
+ *     @OA\Property(property="Hour", type="integer"),
+ *     @OA\Property(property="MaxLicenses", type="integer")
+ * )
  */
 class GroupModuleLimit extends Model
 {

--- a/src/Models/LinkedModule.php
+++ b/src/Models/LinkedModule.php
@@ -2,9 +2,16 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use OpenApi\Annotations as OA;
 
 /**
  * Represents a module link used for fallback checks.
+ *
+ * @OA\Schema(
+ *     schema="LinkedModule",
+ *     @OA\Property(property="GroupCode", type="string"),
+ *     @OA\Property(property="ModuleName", type="string")
+ * )
  */
 class LinkedModule extends Model
 {

--- a/src/Models/ModuleLimit.php
+++ b/src/Models/ModuleLimit.php
@@ -2,9 +2,16 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use OpenApi\Annotations as OA;
 
 /**
  * Representation of the ModuleLimits configuration table.
+ *
+ * @OA\Schema(
+ *     schema="ModuleLimit",
+ *     @OA\Property(property="ModuleName", type="string"),
+ *     @OA\Property(property="MaxLicenses", type="integer")
+ * )
  */
 class ModuleLimit extends Model
 {

--- a/src/Models/Session.php
+++ b/src/Models/Session.php
@@ -2,7 +2,19 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Schema(
+ *     schema="Session",
+ *     @OA\Property(property="SES_SesjaID", type="integer"),
+ *     @OA\Property(property="SES_Komputer", type="string"),
+ *     @OA\Property(property="SES_OpeIdent", type="string"),
+ *     @OA\Property(property="SES_Modul", type="string"),
+ *     @OA\Property(property="SES_Start", type="string", format="date-time"),
+ *     @OA\Property(property="SES_Stop", type="integer", nullable=true)
+ * )
+ */
 class Session extends Model
 {
     /**

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -2,7 +2,18 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Schema(
+ *     schema="User",
+ *     @OA\Property(property="name", type="string"),
+ *     @OA\Property(property="email", type="string"),
+ *     @OA\Property(property="id", type="integer"),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time")
+ * )
+ */
 class User extends Model
 {
     protected $table = 'users';

--- a/src/Models/UserGroup.php
+++ b/src/Models/UserGroup.php
@@ -3,7 +3,16 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Schema(
+ *     schema="UserGroup",
+ *     @OA\Property(property="UserName", type="string"),
+ *     @OA\Property(property="Group", type="string"),
+ *     @OA\Property(property="WindowsUser", type="string", nullable=true)
+ * )
+ */
 class UserGroup extends Model
 {
     protected $table = 'UserGroups';

--- a/src/OpenApiSpec.php
+++ b/src/OpenApiSpec.php
@@ -1,0 +1,22 @@
+<?php
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Info(title="Slim API", version="1.0")
+ *
+ * @OA\Schema(
+ *     schema="UserTimeLeft",
+ *     type="object",
+ *     @OA\Property(property="user", type="string"),
+ *     @OA\Property(property="pc", type="string"),
+ *     @OA\Property(property="time_left", type="integer", nullable=true)
+ * )
+ *
+ * @OA\Schema(
+ *     schema="Schedule",
+ *     type="object",
+ *     additionalProperties=@OA\Schema(type="array", @OA\Items(type="integer"))
+ * )
+ */
+class OpenApiSpec {}

--- a/src/routes.php
+++ b/src/routes.php
@@ -7,10 +7,26 @@ use App\Services\LimitChecker;
 use App\Models\GroupModuleLimit;
 use App\Models\UserGroup;
 use App\Models\ExceptionUser;
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
 
 return function (App $app) {
 
     // ----- Прочие роуты -----
+
+    /**
+     * @OA\Get(
+     *     path="/api/limits/check/{pc}",
+     *     summary="Check license limits for a PC",
+     *     tags={"Limits"},
+     *     @OA\Parameter(name="pc", in="path", required=true, @OA\Schema(type="string")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Limit code",
+     *         @OA\MediaType(mediaType="text/plain", @OA\Schema(type="string"))
+     *     )
+     * )
+     */
     $app->get('/api/limits/check/{pc}', function (Request $request, Response $response, array $args): Response {
         $pc = $args['pc'];
         $checker = new LimitChecker();
@@ -19,6 +35,18 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'text/plain')->withStatus(200);
     });
 
+    /**
+     * @OA\Get(
+     *     path="/api/limits/users",
+     *     summary="Get remaining time for active users",
+     *     tags={"Limits"},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Time left for users",
+     *         @OA\JsonContent(type="array", @OA\Items(ref="#/components/schemas/UserTimeLeft"))
+     *     )
+     * )
+     */
     $app->get('/api/limits/users', function (Request $request, Response $response): Response {
         $checker = new LimitChecker();
         $data = $checker->getUsersTimeLeft();
@@ -26,6 +54,19 @@ return function (App $app) {
         return $response->withHeader("Content-Type", "application/json")->withStatus(200);
     });
 
+    /**
+     * @OA\Get(
+     *     path="/api/schedule/{userName}",
+     *     summary="Get allowed schedule for user",
+     *     tags={"Limits"},
+     *     @OA\Parameter(name="userName", in="path", required=true, @OA\Schema(type="string")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Schedule",
+     *         @OA\JsonContent(ref="#/components/schemas/Schedule")
+     *     )
+     * )
+     */
     $app->get('/api/schedule/{userName}', function (Request $request, Response $response, array $args): Response {
         $checker = new LimitChecker();
         $schedule = $checker->getUserSchedule($args['userName']);
@@ -33,6 +74,19 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'application/json')->withStatus(200);
     });
 
+    /**
+     * @OA\Post(
+     *     path="/api/limits/users/session/stop/{user}",
+     *     summary="Stop user session",
+     *     tags={"Limits"},
+     *     @OA\Parameter(name="user", in="path", required=true, @OA\Schema(type="string")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Result message",
+     *         @OA\MediaType(mediaType="text/plain", @OA\Schema(type="string"))
+     *     )
+     * )
+     */
     $app->post('/api/limits/users/session/stop/{user}', function (Request $request, Response $response, array $args): Response {
         $user = $args['user'];
         $forceKill = $request->getHeaderLine('X-Force-Kill') === '1';
@@ -56,12 +110,38 @@ return function (App $app) {
 
 
     // ----- Group module limits -----
+    /**
+     * @OA\Get(
+     *     path="/api/group-module-limits",
+     *     summary="List group module limits",
+     *     tags={"GroupModuleLimits"},
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of limits",
+     *         @OA\JsonContent(type="array", @OA\Items(ref="#/components/schemas/GroupModuleLimit"))
+     *     )
+     * )
+     */
     $app->get('/api/group-module-limits', function (Request $request, Response $response): Response {
         $limits = GroupModuleLimit::all();
         $response->getBody()->write($limits->toJson());
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    /**
+     * @OA\Get(
+     *     path="/api/group-module-limits/{id}",
+     *     summary="Get group module limit",
+     *     tags={"GroupModuleLimits"},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Limit",
+     *         @OA\JsonContent(ref="#/components/schemas/GroupModuleLimit")
+     *     ),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     $app->get('/api/group-module-limits/{id}', function (Request $request, Response $response, array $args): Response {
         $limit = GroupModuleLimit::find($args['id']);
         if (!$limit) {
@@ -71,6 +151,15 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    /**
+     * @OA\Post(
+     *     path="/api/group-module-limits",
+     *     summary="Create group module limit",
+     *     tags={"GroupModuleLimits"},
+     *     @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/GroupModuleLimit")),
+     *     @OA\Response(response=201, description="Created", @OA\JsonContent(ref="#/components/schemas/GroupModuleLimit"))
+     * )
+     */
     $app->post('/api/group-module-limits', function (Request $request, Response $response): Response {
         $data = json_decode($request->getBody()->getContents(), true);
         $limit = new GroupModuleLimit();
@@ -83,6 +172,17 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'application/json')->withStatus(201);
     });
 
+    /**
+     * @OA\Put(
+     *     path="/api/group-module-limits/{id}",
+     *     summary="Update group module limit",
+     *     tags={"GroupModuleLimits"},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/GroupModuleLimit")),
+     *     @OA\Response(response=200, description="Updated", @OA\JsonContent(ref="#/components/schemas/GroupModuleLimit")),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     $app->put('/api/group-module-limits/{id}', function (Request $request, Response $response, array $args): Response {
         $limit = GroupModuleLimit::find($args['id']);
         if (!$limit) {
@@ -99,6 +199,16 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    /**
+     * @OA\Delete(
+     *     path="/api/group-module-limits/{id}",
+     *     summary="Delete group module limit",
+     *     tags={"GroupModuleLimits"},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=204, description="Deleted"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     $app->delete('/api/group-module-limits/{id}', function (Request $request, Response $response, array $args): Response {
         $limit = GroupModuleLimit::find($args['id']);
         if (!$limit) {
@@ -109,12 +219,38 @@ return function (App $app) {
     });
 
     // ----- User groups -----
+    /**
+     * @OA\Get(
+     *     path="/api/user-groups",
+     *     summary="List user groups",
+     *     tags={"UserGroups"},
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of user groups",
+     *         @OA\JsonContent(type="array", @OA\Items(ref="#/components/schemas/UserGroup"))
+     *     )
+     * )
+     */
     $app->get('/api/user-groups', function (Request $request, Response $response): Response {
         $groups = UserGroup::all();
         $response->getBody()->write($groups->toJson());
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    /**
+     * @OA\Get(
+     *     path="/api/user-groups/{userName}",
+     *     summary="Get user group",
+     *     tags={"UserGroups"},
+     *     @OA\Parameter(name="userName", in="path", required=true, @OA\Schema(type="string")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="User group",
+     *         @OA\JsonContent(ref="#/components/schemas/UserGroup")
+     *     ),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     $app->get('/api/user-groups/{userName}', function (Request $request, Response $response, array $args): Response {
         $group = UserGroup::find($args['userName']); // userName = PK
         if (!$group) {
@@ -124,6 +260,15 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    /**
+     * @OA\Post(
+     *     path="/api/user-groups",
+     *     summary="Create user group",
+     *     tags={"UserGroups"},
+     *     @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/UserGroup")),
+     *     @OA\Response(response=201, description="Created", @OA\JsonContent(ref="#/components/schemas/UserGroup"))
+     * )
+     */
     $app->post('/api/user-groups', function (Request $request, Response $response): Response {
         $data = json_decode($request->getBody()->getContents(), true);
         $group = new UserGroup();
@@ -135,6 +280,17 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'application/json')->withStatus(201);
     });
 
+    /**
+     * @OA\Put(
+     *     path="/api/user-groups/{userName}",
+     *     summary="Update user group",
+     *     tags={"UserGroups"},
+     *     @OA\Parameter(name="userName", in="path", required=true, @OA\Schema(type="string")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/UserGroup")),
+     *     @OA\Response(response=200, description="Updated", @OA\JsonContent(ref="#/components/schemas/UserGroup")),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     $app->put('/api/user-groups/{userName}', function (Request $request, Response $response, array $args): Response {
         $group = UserGroup::find($args['userName']);
         if (!$group) {
@@ -151,6 +307,16 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    /**
+     * @OA\Delete(
+     *     path="/api/user-groups/{userName}",
+     *     summary="Delete user group",
+     *     tags={"UserGroups"},
+     *     @OA\Parameter(name="userName", in="path", required=true, @OA\Schema(type="string")),
+     *     @OA\Response(response=204, description="Deleted"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     $app->delete('/api/user-groups/{userName}', function (Request $request, Response $response, array $args): Response {
         $group = UserGroup::find($args['userName']);
         if (!$group) {
@@ -161,12 +327,38 @@ return function (App $app) {
     });
 
     // ----- Exception users -----
+    /**
+     * @OA\Get(
+     *     path="/api/exception-users",
+     *     summary="List exception users",
+     *     tags={"ExceptionUsers"},
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of exception users",
+     *         @OA\JsonContent(type="array", @OA\Items(ref="#/components/schemas/ExceptionUser"))
+     *     )
+     * )
+     */
     $app->get('/api/exception-users', function (Request $request, Response $response): Response {
         $users = ExceptionUser::all();
         $response->getBody()->write($users->toJson());
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    /**
+     * @OA\Get(
+     *     path="/api/exception-users/{id}",
+     *     summary="Get exception user",
+     *     tags={"ExceptionUsers"},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Exception user",
+     *         @OA\JsonContent(ref="#/components/schemas/ExceptionUser")
+     *     ),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     $app->get('/api/exception-users/{id}', function (Request $request, Response $response, array $args): Response {
         $user = ExceptionUser::find($args['id']);
         if (!$user) {
@@ -176,6 +368,15 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    /**
+     * @OA\Post(
+     *     path="/api/exception-users",
+     *     summary="Create exception user",
+     *     tags={"ExceptionUsers"},
+     *     @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/ExceptionUser")),
+     *     @OA\Response(response=201, description="Created", @OA\JsonContent(ref="#/components/schemas/ExceptionUser"))
+     * )
+     */
     $app->post('/api/exception-users', function (Request $request, Response $response): Response {
         $data = json_decode($request->getBody()->getContents(), true);
         $user = new ExceptionUser();
@@ -185,6 +386,17 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'application/json')->withStatus(201);
     });
 
+    /**
+     * @OA\Put(
+     *     path="/api/exception-users/{id}",
+     *     summary="Update exception user",
+     *     tags={"ExceptionUsers"},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/ExceptionUser")),
+     *     @OA\Response(response=200, description="Updated", @OA\JsonContent(ref="#/components/schemas/ExceptionUser")),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     $app->put('/api/exception-users/{id}', function (Request $request, Response $response, array $args): Response {
         $user = ExceptionUser::find($args['id']);
         if (!$user) {
@@ -199,6 +411,16 @@ return function (App $app) {
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    /**
+     * @OA\Delete(
+     *     path="/api/exception-users/{id}",
+     *     summary="Delete exception user",
+     *     tags={"ExceptionUsers"},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=204, description="Deleted"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     $app->delete('/api/exception-users/{id}', function (Request $request, Response $response, array $args): Response {
         $user = ExceptionUser::find($args['id']);
         if (!$user) {
@@ -206,5 +428,18 @@ return function (App $app) {
         }
         $user->delete();
         return $response->withStatus(204);
+    });
+
+    // ----- Swagger docs -----
+    $app->get('/swagger.json', function (Request $request, Response $response): Response {
+        $openapi = Generator::scan([__DIR__]);
+        $response->getBody()->write($openapi->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
+
+    $app->get('/docs', function (Request $request, Response $response): Response {
+        $html = file_get_contents(__DIR__ . '/../public/swagger.html');
+        $response->getBody()->write($html);
+        return $response->withHeader('Content-Type', 'text/html');
     });
 };


### PR DESCRIPTION
## Summary
- document routes and models with Swagger annotations
- expose `/swagger.json` and `/docs` endpoints for OpenAPI and Swagger UI

## Testing
- `php -l src/OpenApiSpec.php`
- `php -l src/routes.php`
- `php -l src/Models/GroupModuleLimit.php`
- `php -l src/Models/UserGroup.php`
- `php -l src/Models/ExceptionUser.php`
- `php -l src/Models/ModuleLimit.php`
- `php -l src/Models/LinkedModule.php`
- `php -l src/Models/Session.php`
- `php -l src/Models/User.php`

------
https://chatgpt.com/codex/tasks/task_e_689319c4ad248320874d46fedde4fe8f